### PR TITLE
Fix Coding of DCPBlockLength in Suboption Stop

### DIFF
--- a/ProfinetTools.Logic/Protocols/DCP.cs
+++ b/ProfinetTools.Logic/Protocols/DCP.cs
@@ -710,7 +710,7 @@ namespace ProfinetTools.Logic.Protocols
 			if (do_pad) ret += EncodeU8(buffer, 0);
 
 			//BlockQualifier
-			ret += EncodeBlock(buffer, BlockOptions.Control_Stop, (ushort)(2 + data_length));
+			ret += EncodeBlock(buffer, BlockOptions.Control_Stop, (ushort)(2));
 			ret += EncodeU16(buffer, (ushort)qualifiers);
 
 			return ret;


### PR DESCRIPTION
Table 73 of the Protocol-Standard defines the BlockLength to be 0x2.